### PR TITLE
Document skeleton for Central de Alarme parts

### DIFF
--- a/Projetos/Central de Alarme/Introducao.md
+++ b/Projetos/Central de Alarme/Introducao.md
@@ -14,56 +14,58 @@ A Central de Alarme será composta por:
 ---
 
 ## 🛠️ Ferramentas Utilizadas
-- **EasyEDA (Free)** – desenho de esquemáticos e layout PCB  
-- **GitHub** – documentação do projeto em Markdown  
-- **PIC18F4550** – microcontrolador principal  
-- **Datasheets** dos componentes (LED, diodo, display, teclado)  
+- **EasyEDA (Free)** – desenho de esquemáticos e layout PCB
+- **GitHub** – documentação do projeto em Markdown
+- **PIC18F4550** – microcontrolador principal
+- **Datasheets** dos componentes (LED, diodo, display, teclado)
 
 ---
 
 ## 📐 Especificações Técnicas (resumo)
 Conforme referência do professor e cálculos iniciais:
 
-- **LEDs**:  
-  - Vf ≈ 1.2 V, If ≈ 11 mA  
+- **LEDs**:
+  - Vf ≈ 1.2 V, If ≈ 11 mA
   - Resistor calculado: **330 Ω**
 
-- **Display de 7 segmentos**:  
-  - Vf ≈ 1.3 V por segmento, If ≈ 9 mA  
+- **Display de 7 segmentos**:
+  - Vf ≈ 1.3 V por segmento, If ≈ 9 mA
   - Resistor calculado: **430 Ω**
 
-- **Teclado matricial**:  
-  - Corrente alvo ≈ 200 µA  
-  - Diodos: 1N4148 (0.7 V)  
+- **Teclado matricial**:
+  - Corrente alvo ≈ 200 µA
+  - Diodos: 1N4148 (0.7 V)
   - Resistores: **22 kΩ**
 
-- **Sensores**:  
-  - Corrente alvo ≈ 200 µA  
-  - Resistores: **24 kΩ**  
+- **Sensores**:
+  - Corrente alvo ≈ 200 µA
+  - Resistores: **24 kΩ**
   - Entradas **independentes** (não em série)
 
-- **LCD1602**:  
-  - Trimpot de 4.7 kΩ para ajuste de contraste  
+- **LCD1602**:
+  - Trimpot de 4.7 kΩ para ajuste de contraste
 
-- **Oscilador**: cristal 8 MHz + capacitores 27 pF  
-- **Reset**: resistor 10 kΩ + capacitor 1 µF (power-on reset)  
+- **Oscilador**: cristal 8 MHz + capacitores 27 pF
+- **Reset**: resistor 10 kΩ + capacitor 1 µF (power-on reset)
 
 ---
 
 ## 📂 Organização da Documentação
-O projeto será dividido em partes, cada uma em seu próprio arquivo `.md` dentro da pasta `Projetos/Central de Alarme/`:
+Os arquivos atualmente disponíveis na pasta `Projetos/Central de Alarme/` são:
 
-1. **Introdução** (este arquivo)  
-2. **Parte 01 – Base do Projeto** (alimentação, reset, clock, pinagem inicial)  
-3. **Parte 02 – LEDs e Display de 7 segmentos**  
-4. **Parte 03 – Teclado Matricial**  
-5. **Parte 04 – Sensores**  
-6. **Parte 05 – LCD1602**  
-7. **Parte 06 – Firmware**  
-8. **Parte 07 – Checklist Final**  
+1. [Introdução](./Introducao.md)
+2. [Parte 01 – Base do Projeto](./Parte_01_Base_Projeto.md)
+3. [Parte 02 – LEDs e Display de 7 Segmentos](./Parte_02_LEDs_7Segmentos.md)
+4. [Parte 03 – Teclado Matricial 4x3](./Parte_03_Teclado_Matricial.md)
+5. [Parte 04 – Sensores Independentes](./Parte_04_Sensores.md)
+6. [Parte 05 – Display LCD1602](./Parte_05_LCD1602.md)
+7. [Parte 06 – Firmware da Central de Alarme](./Parte_06_Firmware.md)
+8. [Parte 07 – Checklist Final](./Parte_07_Checklist_Final.md)
+
+Cada parte possui seções padronizadas (Objetivo, Esquema, Cálculos e Checklist) com notas técnicas, pendências e datas previstas para conclusão.
 
 ---
 
 ## ✅ Próximos Passos
-- Criar **Parte 01** documentando alimentação, reset, clock e mapa de pinos.  
-- Configurar o ambiente no EasyEDA e salvar os primeiros esquemáticos.  
+- Criar **Parte 01** documentando alimentação, reset, clock e mapa de pinos.
+- Configurar o ambiente no EasyEDA e salvar os primeiros esquemáticos.

--- a/Projetos/Central de Alarme/Parte_01_Base_Projeto.md
+++ b/Projetos/Central de Alarme/Parte_01_Base_Projeto.md
@@ -1,1 +1,20 @@
+# Parte 01 – Base do Projeto
 
+## Objetivo
+- Definir a infraestrutura elétrica da central de alarme baseada no PIC18F4550.
+- Detalhar blocos de alimentação, circuito de reset, clock externo e mapa inicial de pinos.
+
+## Esquema
+> Conteúdo pendente: gerar o diagrama no EasyEDA contemplando fonte 5 V regulada, circuito de reset e oscilador de 8 MHz.
+- Pendências: validar footprint dos conectores e dimensionar trilhas de alimentação.
+- Previsão de entrega: 30/06/2024.
+
+## Cálculos
+> Conteúdo pendente: confirmar o dimensionamento do regulador linear e dos capacitores de filtragem.
+- Pendências: calcular dissipação térmica do regulador e ripple esperado na linha de 5 V.
+- Previsão de entrega: 30/06/2024.
+
+## Checklist
+- [ ] Verificar referências do datasheet do PIC18F4550 para requisitos de clock e reset.
+- [ ] Revisar o layout de alimentação com mentor/professor.
+- [ ] Exportar PDF do esquemático final.

--- a/Projetos/Central de Alarme/Parte_02_LEDs_7Segmentos.md
+++ b/Projetos/Central de Alarme/Parte_02_LEDs_7Segmentos.md
@@ -1,1 +1,20 @@
+# Parte 02 – LEDs e Display de 7 Segmentos
 
+## Objetivo
+- Integrar LEDs indicadores e um display de 7 segmentos para sinalização visual do sistema de alarme.
+- Definir interface elétrica entre o PIC18F4550 e os componentes de saída luminosa.
+
+## Esquema
+> Conteúdo pendente: elaborar o esquemático com transistores de acionamento (se necessário), resistores limitadores e conectores do display.
+- Pendências: confirmar pinagem do display escolhido e mapear bits de controle.
+- Previsão de entrega: 05/07/2024.
+
+## Cálculos
+> Conteúdo pendente: validar cálculos de resistores limitadores considerando Vf/If dos LEDs e multiplexação do display.
+- Pendências: definir corrente máxima por segmento e avaliar dissipação.
+- Previsão de entrega: 05/07/2024.
+
+## Checklist
+- [ ] Selecionar modelo específico do display de 7 segmentos (ânodo comum ou cátodo comum).
+- [ ] Atualizar tabela verdade de acendimento dos segmentos.
+- [ ] Revisar necessidade de transistores para corrente total do display.

--- a/Projetos/Central de Alarme/Parte_03_Teclado_Matricial.md
+++ b/Projetos/Central de Alarme/Parte_03_Teclado_Matricial.md
@@ -1,1 +1,20 @@
+# Parte 03 – Teclado Matricial 4x3
 
+## Objetivo
+- Documentar a interface de leitura de um teclado matricial 4x3 utilizado para armar/desarmar a central.
+- Definir hardware anti-ghosting e rotina de varredura para o firmware.
+
+## Esquema
+> Conteúdo pendente: desenhar matriz com resistores pull-down/pull-up, diodos de proteção e conector para o teclado.
+- Pendências: verificar necessidade de buffers para isolamento e organizar rotas de sinal.
+- Previsão de entrega: 12/07/2024.
+
+## Cálculos
+> Conteúdo pendente: confirmar dimensionamento dos resistores de 22 kΩ e impacto na corrente de varredura.
+- Pendências: avaliar tempos RC e debouncing por hardware.
+- Previsão de entrega: 12/07/2024.
+
+## Checklist
+- [ ] Escolher topologia final (pull-up vs. pull-down) conforme firmware planejado.
+- [ ] Testar diodos 1N4148 no simulador para validar anti-ghosting.
+- [ ] Gerar planilha de mapeamento tecla ↔ endereço lógico.

--- a/Projetos/Central de Alarme/Parte_04_Sensores.md
+++ b/Projetos/Central de Alarme/Parte_04_Sensores.md
@@ -1,1 +1,20 @@
+# Parte 04 – Sensores Independentes
 
+## Objetivo
+- Integrar sensores de intrusão (PIR, magnéticos, etc.) com entradas independentes no PIC18F4550.
+- Garantir isolamento elétrico e filtragem de ruídos provenientes dos sensores.
+
+## Esquema
+> Conteúdo pendente: criar esquemático com optoacopladores/ filtros RC conforme necessidade de cada sensor.
+- Pendências: especificar conectores modulares e planejamento de alimentação auxiliar (12 V → 5 V se aplicável).
+- Previsão de entrega: 19/07/2024.
+
+## Cálculos
+> Conteúdo pendente: dimensionar resistores de pull-up/pull-down e redes RC para debounce/filtragem.
+- Pendências: calcular correntes máximas nos sensores e verificar compatibilidade com optoacopladores.
+- Previsão de entrega: 19/07/2024.
+
+## Checklist
+- [ ] Listar sensores suportados e respectivas características elétricas.
+- [ ] Definir estratégia de detecção de falha (sensor aberto/curto).
+- [ ] Validar necessidade de proteções adicionais (TVS, fusíveis resetáveis).

--- a/Projetos/Central de Alarme/Parte_05_LCD1602.md
+++ b/Projetos/Central de Alarme/Parte_05_LCD1602.md
@@ -1,1 +1,20 @@
+# Parte 05 – Display LCD1602
 
+## Objetivo
+- Integrar o display LCD1602 para apresentar mensagens de status e menus da central de alarme.
+- Definir interface 4 bits ou 8 bits conforme disponibilidade de pinos no PIC18F4550.
+
+## Esquema
+> Conteúdo pendente: montar diagrama com conexão do LCD1602, trimpot de contraste (4,7 kΩ) e backlight (se houver).
+- Pendências: avaliar necessidade de transistor para controle de brilho do backlight.
+- Previsão de entrega: 26/07/2024.
+
+## Cálculos
+> Conteúdo pendente: verificar consumo do backlight e dimensionar resistores limitadores/trimpot.
+- Pendências: calcular orçamento de corrente total do sistema com LCD ativo.
+- Previsão de entrega: 26/07/2024.
+
+## Checklist
+- [ ] Decidir modo de operação (4 bits ou 8 bits) e documentar conexões.
+- [ ] Especificar sequência de inicialização conforme datasheet do LCD.
+- [ ] Preparar tabela de mensagens padrão a serem exibidas.

--- a/Projetos/Central de Alarme/Parte_06_Firmware.md
+++ b/Projetos/Central de Alarme/Parte_06_Firmware.md
@@ -1,1 +1,20 @@
+# Parte 06 – Firmware da Central de Alarme
 
+## Objetivo
+- Desenvolver firmware para leitura de sensores, teclado, atualização de displays e acionamento de sirene/relés.
+- Implementar máquina de estados para modos armado, desarmado e alarme.
+
+## Esquema
+> Conteúdo pendente: criar diagrama de blocos do firmware (fluxogramas ou state machine) e mapear conexões lógicas.
+- Pendências: definir módulos (drivers, camada de aplicação) e planejar testes unitários em bancada.
+- Previsão de entrega: 02/08/2024.
+
+## Cálculos
+> Conteúdo pendente: estimar tempos de varredura do teclado, refresh de display e tempo de resposta da sirene.
+- Pendências: avaliar consumo de CPU e requisitos de temporização (timers internos).
+- Previsão de entrega: 02/08/2024.
+
+## Checklist
+- [ ] Criar repositório de código-fonte (C) com estrutura de diretórios.
+- [ ] Configurar ambiente de compilação (MPLAB X / XC8).
+- [ ] Planejar casos de teste para cada modo de operação.

--- a/Projetos/Central de Alarme/Parte_07_Checklist_Final.md
+++ b/Projetos/Central de Alarme/Parte_07_Checklist_Final.md
@@ -1,1 +1,20 @@
+# Parte 07 – Checklist Final
 
+## Objetivo
+- Consolidar verificações finais de hardware, firmware e documentação antes da entrega da central de alarme.
+- Garantir que todos os requisitos funcionais e de segurança foram atendidos.
+
+## Esquema
+> Conteúdo pendente: elaborar diagrama de integração mostrando a interligação entre módulos (alimentação, sensores, interface de usuário).
+- Pendências: coletar revisões finais dos esquemáticos de cada parte.
+- Previsão de entrega: 09/08/2024.
+
+## Cálculos
+> Conteúdo pendente: fechar balanço energético do sistema (consumo total vs. capacidade da fonte/bateria).
+- Pendências: validar margens de segurança e redundância.
+- Previsão de entrega: 09/08/2024.
+
+## Checklist
+- [ ] Confirmar conclusão dos testes de hardware (queima, continuidade e funcional).
+- [ ] Validar firmware final com casos de uso completos.
+- [ ] Atualizar documentação com versões finais dos arquivos (PDFs, gerbers, firmware).


### PR DESCRIPTION
## Summary
- add standardized documentation skeletons for parts 01 through 07 of the Central de Alarme project, detailing objectives, pending schematic/calculation work and due dates
- update the project introduction to link to the available part files and describe the standardized structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d176463d408333899674bc1cf0cc0f